### PR TITLE
Add `::CODESTYLE` after files in pytest verbose mode

### DIFF
--- a/pytest_docstyle.py
+++ b/pytest_docstyle.py
@@ -48,6 +48,11 @@ class Item(pytest.Item, pytest.File):
         super().__init__(path, parent)
         self.add_marker('docstyle')
 
+        # https://github.com/pytest-dev/pytest/blob/92d6a0500b9f528a9adcd6bbcda46ebf9b6baf03/src/_pytest/nodes.py#L380
+        # https://github.com/pytest-dev/pytest/blob/92d6a0500b9f528a9adcd6bbcda46ebf9b6baf03/src/_pytest/nodes.py#L101
+        # https://github.com/moccu/pytest-isort/blob/44f345560a6125277f7432eaf26a3488c0d39177/pytest_isort.py#L142
+        self._nodeid += '::DOCSTYLE'
+
     def setup(self):
         old_mtime = self.config.cache.get(self.CACHE_KEY, {}).get(str(self.fspath), -1)
         mtime = self.fspath.mtime()

--- a/test_pytest_docstyle.py
+++ b/test_pytest_docstyle.py
@@ -1,6 +1,6 @@
 import pytest_docstyle
 
-# https://docs.pytest.org/en/latest/writing_plugins.html#testing-plugins
+# https://docs.pytest.org/en/5.2.2/writing_plugins.html#testing-plugins
 pytest_plugins = ["pytester"]
 
 
@@ -101,6 +101,19 @@ def test_strict(testdir):
     p = p.write(p.read() + "\n")
     result = testdir.runpytest('--strict', '--docstyle')
     result.assert_outcomes(passed=1)
+
+
+def test_nodeid(testdir):
+    p = testdir.makepyfile(nodeid='''
+        """Test _nodeid."""
+        def test_nodeid():
+            """Test."""
+            pass
+    ''')
+    p = p.write(p.read() + "\n")
+    result = testdir.runpytest('-m', 'docstyle', '--docstyle', '-v')
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(['nodeid.py::DOCSTYLE PASSED *'])
 
 
 class TestItem(object):


### PR DESCRIPTION
https://github.com/henry0312/pytest-codestyle/pull/52
https://github.com/henry0312/pytest-codestyle/pull/54
https://github.com/henry0312/pytest-codestyle/pull/55