### PR TITLE
Fix PytestDeprecationWarning since pytest v5.4

### DIFF
--- a/pytest_pydocstyle.py
+++ b/pytest_pydocstyle.py
@@ -1,3 +1,6 @@
+# https://docs.pytest.org/en/latest/writing_plugins.html
+# https://docs.pytest.org/en/latest/example/nonpython.html#yaml-plugin
+
 import contextlib
 import logging
 import sys
@@ -39,20 +42,34 @@ def pytest_collect_file(parent, path):
         with _patch_sys_argv(args):
             parser.parse()
         for filename, _, _ in parser.get_files_to_check():
-            return Item(path, parent, parser)
+            # store config parser of pydocstyle
+            parent.config_parser = parser
+            # https://github.com/pytest-dev/pytest/blob/ee1950af7793624793ee297e5f48b49c8bdf2065/src/_pytest/nodes.py#L477
+            return File.from_parent(parent=parent, fspath=path)
 
 
-class Item(pytest.Item, pytest.File):
+class File(pytest.File):
+
+    def collect(self):
+        # https://github.com/pytest-dev/pytest/blob/ee1950af7793624793ee297e5f48b49c8bdf2065/src/_pytest/nodes.py#L399
+        return [Item.from_parent(name=self.name, parent=self.parent, nodeid=self.nodeid, fspath=self.fspath)]
+
+
+class Item(pytest.Item):
     CACHE_KEY = 'pydocstyle/mtimes'
 
-    def __init__(self, path, parent, parser):
-        super().__init__(path, parent)
+    def __init__(self, name, parent, nodeid, fspath):
+        nodeid += "::PYDOCSTYLE"  # TODO: use f-string
+        # https://github.com/pytest-dev/pytest/blob/ee1950af7793624793ee297e5f48b49c8bdf2065/src/_pytest/nodes.py#L544
+        super().__init__(name, parent=parent, nodeid=nodeid)
         self.add_marker('pydocstyle')
-        self.parser = parser
-        # https://github.com/pytest-dev/pytest/blob/92d6a0500b9f528a9adcd6bbcda46ebf9b6baf03/src/_pytest/nodes.py#L380
-        # https://github.com/pytest-dev/pytest/blob/92d6a0500b9f528a9adcd6bbcda46ebf9b6baf03/src/_pytest/nodes.py#L101
-        # https://github.com/moccu/pytest-isort/blob/44f345560a6125277f7432eaf26a3488c0d39177/pytest_isort.py#L142
-        self._nodeid += '::PYDOCSTYLE'
+
+        # update fspath that was defined as parent.fspath in Node.__init__
+        # https://github.com/pytest-dev/pytest/blob/ee1950af7793624793ee297e5f48b49c8bdf2065/src/_pytest/nodes.py#L126
+        self.fspath = fspath
+
+        # load config parser of pydocstyle
+        self.parser = parent.config_parser
 
     def setup(self):
         if not hasattr(self.config, 'cache'):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     py_modules=['pytest_pydocstyle'],
     python_requires='~=3.5',
     install_requires=[
-        'pytest',
+        'pytest~=5.4',
         'pydocstyle',
     ],
     extras_require={


### PR DESCRIPTION
```
/usr/local/lib/python3.7/site-packages/pytest_pydocstyle.py:42: PytestDeprecationWarning: direct construction of Item has been deprecated, please use Item.from_parent
  return Item(path, parent, parser)
```